### PR TITLE
Proposed SwerveDrive updates

### DIFF
--- a/src/main/include/subsystems/SwerveDrive.h
+++ b/src/main/include/subsystems/SwerveDrive.h
@@ -14,7 +14,8 @@ namespace t34 {
 
         void ToggleFarisMode();
         void Drive(frc::Translation2d translation, double rotation, bool field_relative = true, bool is_open_loop = false);
-        void DriveAuto(frc::ChassisSpeeds speeds);
+        void Drive(frc::ChassisSpeeds robot_relative_speeds, bool is_open_loop);
+        void DriveAuto(frc::ChassisSpeeds robot_relative_speeds);
         void Stop();
 
 


### PR DESCRIPTION
Created separate `Drive(frc::ChassisSpeeds, bool)` function that both `Drive(Translation2d, double, bool, bool)` and `DriveAuto(ChassisSpeeds)`.

Eliminates the need to convert `ChassisSpeeds` into `Translation2d`.