### PR TITLE
Renamed POV constants

### DIFF
--- a/src/main/cpp/Robot.cpp
+++ b/src/main/cpp/Robot.cpp
@@ -187,21 +187,21 @@ void Robot::TeleopPeriodic() {
     //Set the robot's target mode with the D-Pad
     switch (rc->ctrl->GetPOV())
     {
-        case (POV_AMP): //  up
+        case (POV_UP): //  amp
             rc->shooter.SetMaxSpeedPercent(0.1);
             rc->limelight_util.TargetAmp();
             rc->arm_angle_setpoint = 87.18;
             break;
-        case (POV_SPEAKER): // right
+        case (POV_RIGHT): // speaker
             rc->shooter.SetMaxSpeedPercent(1.0);
             rc->limelight_util.TargetSpeaker();
             //rc->shooter.MoveToAngleDeg(rc->limelight_util.m_math_handler.GetFiringAngleDeg());
             rc->arm_angle_setpoint = 45.0;
             break;
-        case (POV_REST): // 
+        case (POV_DOWN): // rest
             rc->arm_angle_setpoint = 90;
             break;
-        case (POV_COLLECTION): // left
+        case (POV_LEFT): // note collection
             rc->shooter.SetMaxSpeedPercent(0.0);
             rc->arm_angle_setpoint = 12.0;
             break;

--- a/src/main/include/Constants.h
+++ b/src/main/include/Constants.h
@@ -21,10 +21,10 @@ constexpr double LIMELIGHT_DEGREE_SCALAR{23.188 / 20.25};//{ 21.1726 / 22.5 };
 
 const std::string LIMELIGHT_TABLE_NAME{ "" };
 
-const int POV_AMP{ 0 };
-const int POV_SPEAKER{ 90 };
-const int POV_REST{ 180 };
-const int POV_COLLECTION{ 270 };
+const int POV_UP{ 0 };
+const int POV_RIGHT{ 90 };
+const int POV_DOWN{ 180 };
+const int POV_LEFT{ 270 };
 
 #define DEG_TO_RAD(x) (x * PI_DIV_180)
 #define RAD_TO_DEG(x) (x * _180_DIV_PI)


### PR DESCRIPTION
The directions (up, down, left, right) accord better to what the user has done.

The switch statement maps those directions to the user's intent (or at least, our interpretation of his/her intent).